### PR TITLE
Add compatibiity with gbp >+ 0.8 and drop support for < 0.6, implement support for git submodules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Build-Depends: debhelper (>= 9)
 Package: obs-service-git-buildpackage
 Section: misc
 Architecture: all
-Depends: ${misc:Depends}, devscripts, fakeroot, git-buildpackage, gawk
+Depends: ${misc:Depends}, devscripts, fakeroot, git-buildpackage (>= 0.6.0), gawk
 Description: $prefix OBS source service version
  This package sets up the version for an OBS package build

--- a/git_buildpackage
+++ b/git_buildpackage
@@ -120,8 +120,6 @@ def fetch_upstream(url, revision, out_dir):
 
         safe_run(['git', 'clone', '--no-checkout', url, clone_dir],
                  cwd=out_dir, interactive=sys.stdout.isatty())
-#        safe_run(['git', 'submodule', 'update', '--init', '--recursive'],
-#                 cwd=clone_dir)
     else:
         logging.info("Detected cached repository...")
 #        UPDATE_CACHE_COMMANDS[scm](url, clone_dir, revision)
@@ -146,7 +144,7 @@ def sanitize_build_args(build_args):
 
     return gbp_args + dpkg_args
 
-def create_source_package(repo_dir, output_dir, revision, build_args):
+def create_source_package(repo_dir, output_dir, revision, build_args, submodules):
     """Create source package via git-buildpackage"""
 
     if not revision:
@@ -159,6 +157,11 @@ def create_source_package(repo_dir, output_dir, revision, build_args):
     # use the --git-export option
     command.extend(['--git-ignore-branch', "--git-export-dir=%s" % output_dir,
                     "--git-export=%s" % revision])
+
+    # GBP can load submodules without having to run the git command, and will
+    # ignore submodules even if loaded manually unless this option is passed.
+    if submodules:
+        command.extend(['--git-submodules'])
 
     # create local pristine-tar branch
     try:
@@ -227,8 +230,9 @@ if __name__ == '__main__':
                         help='upstream tarball URL to download')
     parser.add_argument('--revision',
                         help='revision to package')
-    parser.add_argument('--submodules',
-                        help='osc service parameter that does nothing')
+    parser.add_argument('--submodules', choices=['enable', 'disable'],
+                        default='enable',
+                        help='Include git submodules in source artefact')
     parser.add_argument('--outdir', required=True,
                         help='osc service parameter that does nothing')
     parser.add_argument('--build_args', type=str,
@@ -261,6 +265,11 @@ if __name__ == '__main__':
     else:
         args.dch_release_update = False
 
+    if args.submodules == 'enable':
+        args.submodules = True
+    else:
+        args.submodules = False
+
     #
     # real main
     #
@@ -283,7 +292,8 @@ if __name__ == '__main__':
 
     # create_source_package
     create_source_package(clone_dir, repodir, revision=revision,
-                          build_args=args.build_args)
+                          build_args=args.build_args,
+                          submodules=args.submodules)
 
     # copy_source_package
     copy_source_package(repodir, args.outdir)

--- a/git_buildpackage
+++ b/git_buildpackage
@@ -152,7 +152,7 @@ def create_source_package(repo_dir, output_dir, revision, build_args):
     if not revision:
         revision = 'master'
 
-    command = ['git', 'buildpackage', '--git-notify=off', '--git-force-create',
+    command = ['gbp', 'buildpackage', '--git-notify=off', '--git-force-create',
                '--git-cleaner="true"' ]
 
     # we are not on a proper local branch due to using git-reset but we anyway

--- a/obs-service-git_buildpackage.spec
+++ b/obs-service-git_buildpackage.spec
@@ -25,7 +25,7 @@ Release:        0
 Source:         %{name}-%{version}.tar.gz
 Requires:       sed
 Requires:       gawk
-Requires:       git-buildpackage
+Requires:       git-buildpackage >= 0.6.0
 Requires:       fakeroot
 Requires:       devscripts
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
Newer versions of gbp have deprecated the "git buildpackage" and
"git-buildpackage" commands in favour of "gbp buildpackage".
Support for the latter was added in 0.6.0 released on 26 Jun 2013 so
time to move on.


On Debian 9:

```
$ osc service disabledrun
Enter passphrase for key '/home/lboccass/.ssh/id_rsa': 
Cloning into '/home/lboccass/VR:5600:17.1.0:a/linux-vyatta/tmpRVmztu.git_buildpackage.service/tmp1tELnu/linux-vyatta.git'...
Checking out files: 100% (57173/57173), done.
HEAD is now at cba62c0ebe4c Update changelog for 4.8.17-0vyatta2 release
git: 'buildpackage' is not a git command. See 'git --help'.
ERROR(1): git buildpackage --git-notify=off --git-force-create --git-cleaner="true" --git-ignore-branch --git-export-dir=/home/lboccass/VR:5600:17.1.0:a/linux-vyatta/tmpRVmztu.git_buildpackage.service/tmp1tELnu --git-export=origin/linux-vyatta-4.8.y --git-no-pristine-tar -nc -uc -us -S:
"git: 'buildpackage' is not a git command. See 'git --help'."
```

@jblunck 