### PR TITLE
Share repository cache with obs_scm - option 1, service chaining

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ Package: obs-service-git-buildpackage
 Section: misc
 Architecture: all
 Depends: ${misc:Depends}, devscripts, fakeroot, git-buildpackage (>= 0.6.0), gawk
+Recommends: obs-service-tar-scm (>= 0.6),
 Description: $prefix OBS source service version
  This package sets up the version for an OBS package build

--- a/git_buildpackage
+++ b/git_buildpackage
@@ -22,6 +22,8 @@ import hashlib
 import tempfile
 import logging
 import glob
+import hashlib
+import fcntl
 import ConfigParser
 import StringIO
 
@@ -107,7 +109,7 @@ def switch_revision(clone_dir, revision):
     return revision
 
 
-def fetch_upstream(url, revision, out_dir):
+def fetch_upstream(url, revision, out_dir, git_reference=None):
     """Fetch sources from repository and checkout given revision."""
 
     # calc_dir_to_clone_to
@@ -118,8 +120,13 @@ def fetch_upstream(url, revision, out_dir):
         # initial clone
         os.mkdir(clone_dir)
 
-        safe_run(['git', 'clone', '--no-checkout', url, clone_dir],
-                 cwd=out_dir, interactive=sys.stdout.isatty())
+        command = ['git', 'clone', '--no-checkout', url, clone_dir]
+        # cached repository by obs_scm
+        if git_reference is not None:
+            command.insert(3, '--reference')
+            command.insert(4, git_reference)
+
+        safe_run(command, cwd=out_dir, interactive=sys.stdout.isatty())
     else:
         logging.info("Detected cached repository...")
 #        UPDATE_CACHE_COMMANDS[scm](url, clone_dir, revision)
@@ -203,6 +210,42 @@ def copy_source_package(input_dir, output_dir):
             shutil.copy(input_file, output_file)
 
 
+def obs_scm_cache_from_url(url, config_cache_dir):
+    """Derive cache from url and check if it is present and return it, NONE otherwise."""
+
+    # Adapted from obs_scm/TarSCM/scm/base.py
+    # Each repository is cached in a directory which is named after the
+    # full git URL (utf8) SHA256 sum, which will contain a lock file and the bare git
+    # repository. The cache top level dir might vary.
+    #
+    # check for enabled caches in this order (first wins):
+    #   1. local .cache
+    #   2. environment
+    #   3. user config
+    #   4. system wide
+    cachedir  = None
+    cwd = os.getcwd()
+    if os.path.isdir(os.path.join(cwd, '.cache')):
+        cachedir = os.path.join(cwd, '.cache')
+
+    if cachedir is None:
+        cachedir = os.getenv('CACHEDIRECTORY')
+
+    if cachedir is None:
+        cachedir = config_cache_dir
+
+    if cachedir:
+        logging.debug("REPOCACHE: %s", cachedir)
+        url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
+        repodir = os.path.join(cachedir, url_hash)
+        basename = os.path.basename(re.sub(r'\.git$', '', url))
+        repodir = os.path.abspath(os.path.join(repodir, basename))
+        if os.path.isdir(repodir):
+            return repodir
+
+    return None
+
+
 if __name__ == '__main__':
     FORMAT = "%(message)s"
     logging.basicConfig(format=FORMAT, stream=sys.stderr, level=logging.INFO)
@@ -243,6 +286,9 @@ if __name__ == '__main__':
     parser.add_argument('--dch-release-update', choices=['enable', 'disable'],
                         default='disable',
                         help='Append OBS release number')
+    parser.add_argument('--cache-dir', type=str,
+                        default='',
+                        help='obs_scm git repositories cache directory')
 
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='enable verbose output')
@@ -284,8 +330,16 @@ if __name__ == '__main__':
         repodir = tempfile.mkdtemp(dir=args.outdir)
         CLEANUP_DIRS.append(repodir)
 
+    # if obs_scm created a cached (bare) repository, clone from it
+    # git uses hard links  when cloning locally, so even with very
+    # large repositories it should be very efficient
+    if len(args.cache_dir) > 0:
+        git_reference = obs_scm_cache_from_url(args.url, args.cache_dir)
+    else:
+        git_reference = None
+
     # initial_clone
-    clone_dir = fetch_upstream(args.url, args.revision, repodir)
+    clone_dir = fetch_upstream(args.url, args.revision, repodir, git_reference)
 
     # switch_to_revision
     revision = switch_revision(clone_dir, args.revision)

--- a/git_buildpackage.service
+++ b/git_buildpackage.service
@@ -1,7 +1,10 @@
 <service name="git_buildpackage">
   <summary>An OBS service that uses git buildpackage</summary>
   <description>This OBS service is using git buildpackage to create the debian
-  source package.</description>
+  source package.
+  It can either do a fresh git clone, when the --url parameter is passed, or
+  use a pre-cloned directory, when --cache is used. The latter is useful
+  when combined with obs_scm, which caches the git repository.</description>
 
   <parameter name="url">
     <description>URL to clone GIT repository from</description>
@@ -49,6 +52,15 @@
     <description>Append OBS release number.  Default is 'disable'</description>
     <allowedvalue>enable</allowedvalue>
     <allowedvalue>disable</allowedvalue>
+  </parameter>
+
+  <parameter name="cache-dir">
+    <description>obs_scm top level cache directory, eg: /var/cache/obs/tar_scm
+    If enabled, and if a cached repository created by obs_scm exists,
+    it will be used. Caches are keyed on the full repository URL.
+    WARNING: you must use this only when chaining after an obs_scm run in _service
+    otherwise the cached repository will not be updated and it will be stale.
+    Default is empty string</description>
   </parameter>
 
 </service>

--- a/obs-service-git_buildpackage.spec
+++ b/obs-service-git_buildpackage.spec
@@ -28,6 +28,7 @@ Requires:       gawk
 Requires:       git-buildpackage >= 0.6.0
 Requires:       fakeroot
 Requires:       devscripts
+Recommends:     obs-service-obs_scm >= 0.6
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
The obs_scm service caches git clones and reuses them, greatly
reducing waiting times and bandwidth usage among other things.
Unfortunately it only exposes to the source services (or build
services) the checkout without the .git metadata. It also does
not support the most common Debian workflow, which does not store
the .dsc in the repository, given it's the output of a build.

If a cached repository is present, clone from it rather than from the
URL. Git is clever and uses hard links when possible so it's fast.

This allows to chain obs_scm, which does not create a .dsc, with the
git-buildpackage service which can take care of that.