### PR TITLE
Share repository cache with obs_scm - option 2, import obs_scm modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ Package: obs-service-git-buildpackage
 Section: misc
 Architecture: all
 Depends: ${misc:Depends}, devscripts, fakeroot, git-buildpackage (>= 0.6.0), gawk
+Recommends: obs-service-tar-scm (>= 0.6),
 Description: $prefix OBS source service version
  This package sets up the version for an OBS package build

--- a/git_buildpackage
+++ b/git_buildpackage
@@ -203,6 +203,52 @@ def copy_source_package(input_dir, output_dir):
             shutil.copy(input_file, output_file)
 
 
+def obs_scm_cached_clone(args):
+    """Use obs_scm to do a cached clone and checkout. Returns clone directory or None"""
+
+    try:
+        sys.path.append(os.path.dirname('/usr/lib/obs/service/TarSCM'))
+        from TarSCM.tasks import Tasks
+        from TarSCM.cli import Cli
+    except ImportError:
+        try:
+            from TarSCM.tasks import tasks as Tasks
+            from TarSCM.cli import cli as Cli
+        except ImportError:
+            return None
+
+    # obs_scm has a lot of parameters, we want defaults for everything
+    # use_obs_scm and scm do not have defaults
+    cli = Cli()
+    argv = ["--url", args.url, "--revision", args.revision, "--outdir", args.outdir]
+    cli.parse_args(argv)
+    # avoid creating a package.tar that will confuse obs-build
+    cli.use_obs_scm = True
+    # do not override the repository version
+    cli.version = "_none_"
+    cli.scm = 'git'
+
+    # the task class is the main entry point of the libraries, and by
+    # setting scm to git and use_obs_scm to True it will clone and
+    # create the obs_cpio file.
+    # The Tasks class was refactored in 0.8.0.
+    try:
+        obs_scm = Tasks(cli)
+        obs_scm.generate_list()
+        obs_scm.process_list()
+        obs_scm.finalize()
+    except TypeError:
+        obs_scm = Tasks()
+        obs_scm.generate_list(cli)
+        obs_scm.process_list()
+        obs_scm.finalize(cli)
+
+    # unlocks the cache and removes the temporary sparse clone
+    atexit.register(obs_scm.cleanup)
+
+    return obs_scm.scm_object.clone_dir
+
+
 if __name__ == '__main__':
     FORMAT = "%(message)s"
     logging.basicConfig(format=FORMAT, stream=sys.stderr, level=logging.INFO)
@@ -243,6 +289,9 @@ if __name__ == '__main__':
     parser.add_argument('--dch-release-update', choices=['enable', 'disable'],
                         default='disable',
                         help='Append OBS release number')
+    parser.add_argument('--cache', choices=['enable', 'disable'],
+                        default='enable',
+                        help='use pre-cached git clone directory (requires obs_scm)')
 
     parser.add_argument('--verbose', '-v', action='store_true',
                         help='enable verbose output')
@@ -284,11 +333,23 @@ if __name__ == '__main__':
         repodir = tempfile.mkdtemp(dir=args.outdir)
         CLEANUP_DIRS.append(repodir)
 
-    # initial_clone
-    clone_dir = fetch_upstream(args.url, args.revision, repodir)
+    clone_dir = None
 
-    # switch_to_revision
-    revision = switch_revision(clone_dir, args.revision)
+    # if obs_scm created a cached (bare) repository, clone from it
+    # git uses hard links  when cloning locally, so even with very
+    # large repositories it should be very efficient
+    if args.cache == 'enable':
+        # The temporary sparse clone done by obs_scm already has the
+        # right version, so no need to switch again
+        revision = 'WC'
+        clone_dir = obs_scm_cached_clone(args)
+
+    if clone_dir is None:
+        # initial_clone
+        clone_dir = fetch_upstream(args.url, args.revision, repodir)
+
+        # switch_to_revision
+        revision = switch_revision(clone_dir, args.revision)
 
     # create_source_package
     create_source_package(clone_dir, repodir, revision=revision,

--- a/git_buildpackage.service
+++ b/git_buildpackage.service
@@ -1,7 +1,9 @@
 <service name="git_buildpackage">
   <summary>An OBS service that uses git buildpackage</summary>
   <description>This OBS service is using git buildpackage to create the debian
-  source package.</description>
+  source package.
+  When obs-service-obs_scm is present and --cache is enabled (default), obs_scm
+  cached git clones will be used and shared (keyed on the full URL).</description>
 
   <parameter name="url">
     <description>URL to clone GIT repository from</description>
@@ -47,6 +49,14 @@
 
   <parameter name="dch-release-update">
     <description>Append OBS release number.  Default is 'disable'</description>
+    <allowedvalue>enable</allowedvalue>
+    <allowedvalue>disable</allowedvalue>
+  </parameter>
+
+  <parameter name="cache">
+    <description>If enabled, and if a cached repository created by obs_scm exists,
+    it will be used. Caches are keyed on the full repository URL.
+    Requires obs-service-obs_scm. Default is 'enable'</description>
     <allowedvalue>enable</allowedvalue>
     <allowedvalue>disable</allowedvalue>
   </parameter>

--- a/obs-service-git_buildpackage.spec
+++ b/obs-service-git_buildpackage.spec
@@ -28,6 +28,7 @@ Requires:       gawk
 Requires:       git-buildpackage >= 0.6.0
 Requires:       fakeroot
 Requires:       devscripts
+Recommends:     obs-service-obs_scm >= 0.6
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 


### PR DESCRIPTION
The obs_scm service caches git clones and reuses them, greatly
reducing waiting times and bandwidth usage among other things.
Unfortunately it only exposes to the source services (or build
services) the checkout without the .git metadata. It also does
not support the most common Debian workflow, which does not store
the .dsc in the repository, given it's the output of a build.

If a cached repository is present, clone from it rather than from the
URL. Git is clever and uses hard links when possible so it's fast.

This is done by using obs_scm Python libraries to avoid reinventing
the wheel, although technically it's not a public library so the API
could change.